### PR TITLE
Better referencing to the pth-toolkit so stuff works

### DIFF
--- a/README
+++ b/README
@@ -11,13 +11,19 @@ Written because we got sick of Metasploit PSExec getting popped
 Special thanks to Carnal0wnage who's blog inspired us to go this route.
 http://carnal0wnage.attackresearch.com/2012/01/psexec-fail-upload-and-exec-instead.html
 
-v2.0 - 10/17/2013
+v2.2 - 20170202
+Patches by YG-HT added to enable install on non-Kali distros.
+
+v2.1 - 20170101
+Project has been abandonned by original author, Leostat forks ready to make fixes and improvements
+
+v2.0 - 20131017
 UPDATED - Rubified ;)
 
-v1.2.9.1 - 07/31/2013
+v1.2.9.1 - 20130731
 ADDED - r3dy (pentestgeek.com) created a custom cachedump.rb that is a standalone tool to extract dcc's. This tool extracts non-vista and vista style cached creds. Built based off the cachedump metasploit module create by Carlos Perez (DarkOperator)
 
-v1.2.9 - 07/15/2013
+v1.2.9 - 20130715
 UPDATED - wce has been updated with a universal binary with new version released by the developer (v1.41) as usual its obfuscated ;)
 FIXED - on occasion when a Ctrl-C is inititated, if the smbexec proj folder is empty it will delete it and not recreate
 FIXED - Typo in the f_dsusers function for sys file path
@@ -27,23 +33,23 @@ Windows Credentials Editor v1.41beta
 written by: hernan@ampliasecurity.com
 http://www.ampliasecurity.com
 
-v1.2.8.1 - 06/24/2013
+v1.2.8.1 - 20130624
 UPDATED - Added 'make' install check since libesedb and nmap rely on it for compile
 UPDATED - DA/EA checker still not working as I wanted, ugly grep hacks to make it perform better.
  
-v1.2.8 - 05/22/2013
+v1.2.8 - 20130522
 ADDED - If you have crypter.exe installed on your system it will encrypt your payload after obfuscation. (uncomment line 46)
 ADDED - Will prompt you if you'd like to execute payload as user or SYSTEM
 ADDED - Option to gain a command shell from a remote system without a payload
 FIXED - DA check gives system error 5 "Access Denied" changed it to complete the tasks as SYSTEM -> Thx Craig Freyman for bug report and fix
 UPDATED - Fix payload creation issues, triggered DEP when combined with crypter.exe option. Thx to Hostess for the code!
 
-v1.2.7 - 04/01/2013
+v1.2.7 - 20130401
 FIXED - False positives from Admin check option
 FIXED - Domain cached creds logic I brok in last release
 UPDATED - The whole look and feel is less gaudy and borrow heavily from msfconsole
 
-v1.2.6 - 02/25/2013
+v1.2.6 - 20130225
 ADDED - wce.exe for 64 Bit systems
 FIXED - DA/EA checker did not check for any errors and would falsely state users were on the system that did not exist
 FIXED - Option to just create payload and RC file would continue by launching attack. Now operating as expected
@@ -52,19 +58,19 @@ UPDATE - dcc hash file & cleartext password file is only moved into logfolder if
 UPDATE - source code for samba is now v3.6.12 for compiling smbexeclient binary
 UPDATE - Installer now installs nmap verision 6.25 (Only if nmap is not found on the system. It does not version check)
 
-v1.2.5 - 02/19/2013
+v1.2.5 - 20130219
 FIXED - Issues with proper mingw identification, especially for 64 Bit systems - Bug reported by Jim Broome
 UPDATE - Installer was updated with extra prereqs for winexe compilation.
 TESTING - Install and execution of smbexec was tested again on Ubuntu 12.04 and Fedora 17 64Bit systems
 
-v1.2.4 - 02/04/2013
+v1.2.4 - 20130204
 UPDATE - Added UAC functionality. Now you can check systems to see if they have UAC enabled. In addition, you can disable or enable UAC on systems
 
-v1.2.3 - 01/20/2013
+v1.2.3 - 20130120
 UPDATE - Changed menu layout, was getting crowded on the main page. Combined like tasks.
 FIXED - Hash folder creation wasn't checking for existing folder before trying to create. Resulted in error message.
 
-v1.2.2 - 01/17/2013
+v1.2.2 - 20130117
 UPDATE - Check credentials for remote login capabilities
 UPDATE - Checks systems for DA/EA users logged in or running processes
 UPDATE - If wce.exe is place in the smbexec/progs/ directory it will upload and execute on the target to obtain cleartext credentials from memory during hash grab
@@ -77,13 +83,13 @@ Windows Credentials Editor v1.3beta
 written by: hernan@ampliasecurity.com
 http://www.ampliasecurity.com
 
-v1.2.0 - 11/30/2012
+v1.2.0 - 20121130
 FIXED - Script now checks to ensure exe's are compiled before running. Alerts user to use installer to compile.
 UPDATE - Added drive and path variables to ntds hash grab function. (No longer hardcoded to C:\Windows\NTDS or C:\Windows\Temp)
 UPDATE - Checks for available diskspace before copying ntds.dit and sys files to the path provided
 UPDATE - Deletes the volume shadow copy created by the ntds hash grab function
 
-v1.1.1 - 11/11/2012
+v1.1.1 - 20121111
 FIXED - Sometimes the IP validation fails even though it is a proper IP address
 UPDATE - Installer updated with Samba-3.6.9 source
 UPDATE - libesedb project moved to Google Code, installer updated with proper path  

--- a/install.sh
+++ b/install.sh
@@ -260,25 +260,29 @@ f_libesedb(){
 esedbexportinstall=$(locate -l 1 -b "\esedbexport")
 
 if [ ! -z "$esedbexportinstall" ]; then
-	echo -e "\e[1;32m[+]\e[0m I found esedbexport on your system"
+        echo -e "\e[1;32m[+]\e[0m I found esedbexport on your system"
 else
-	update=1
-	echo -e "\n\e[1;34m[*]\e[0m Downloading libesedb from authors google docs drive..."
-	sleep 2
-	wget --no-check-certificate http://pkgs.fedoraproject.org/repo/pkgs/libesedb/libesedb-alpha-20120102.tar.gz/198a30c98ca1b3cb46d10a12bef8deaf/libesedb-alpha-20120102.tar.gz -O /tmp/smbexec-inst/libesedb-alpha-20120102.tar.gz
-	tar -zxf /tmp/smbexec-inst/libesedb-alpha-20120102.tar.gz -C /tmp/smbexec-inst/
-	currentpath=$PWD
-	echo -e "\n\e[1;34m[*]\e[0m Compiling esedbtools..."
-	sleep 2
-	cd /tmp/smbexec-inst/libesedb-20120102/
-	CFLAGS="-g -O2 -Wall -fgnu89-inline" ./configure --enable-static-executables && make
-	mv /tmp/smbexec-inst/libesedb-20120102/esedbtools /opt/esedbtools
-	cd "$currentpath"
-	if [ -e /opt/esedbtools/esedbexport ] && [ -x /opt/esedbtools/esedbexport ]; then
-		echo -e "\n\e[1;32m[+]\e[0m esedbtools have been installed..."
-	else
-		echo -e "\e[1;31m[!]\e[0m esedbtools didn't install properly. You may need to do it manually"
-	fi
+        update=1
+        echo -e "\n\e[1;34m[*]\e[0m Downloading libesedb from authors Fedora repo..."
+        sleep 2
+        # download the source into directory and extract
+        mkdir dependancies
+        wget --no-check-certificate http://pkgs.fedoraproject.org/repo/pkgs/libesedb/libesedb-alpha-20120102.tar.gz/198a30c98ca1b3cb46d10a12bef8deaf/libesedb-alpha-20120102.tar.gz -O dependancies/libesedb-alpha-20120102.tar.gz
+        tar -zxf dependancies/libesedb-alpha-20120102.tar.gz -C dependancies/
+        # compile esedb
+        currentpath=$PWD
+        echo -e "\n\e[1;34m[*]\e[0m Compiling esedbtools..."
+        sleep 2
+        cd dependancies/libesedb-20120102/
+        CFLAGS="-g -O2 -Wall -fgnu89-inline" ./configure --enable-static-executables && make
+        # mv source to expected location
+        cd "$currentpath"
+        mv dependancies/libesedb-20120102/esedbtools /opt/esedbtools
+        if [ -e /opt/esedbtools/esedbexport ] && [ -x /opt/esedbtools/esedbexport ]; then
+                echo -e "\n\e[1;32m[+]\e[0m esedbtools have been installed..."
+        else
+                echo -e "\e[1;31m[!]\e[0m esedbtools didn't install properly. You may need to do it manually"
+        fi
 fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -332,9 +332,9 @@ if [ ! $(grep -i kali /etc/issue) ]; then
                 git clone https://github.com/byt3bl33d3r/pth-toolkit.git
 	fi
 	# symlink the library files to be inside "smbexec/lib" so they are accessible for binaries with relative paths hard coded
-	for file in $(ls -l /opt/pth-toolkit/lib/ | grep -v "^d" | awk {'print $9'}); do ln -s /opt/pth-toolkit/lib/$file /opt/smbexec/lib/$file; done
+	for file in $(ls --color=never -l /opt/pth-toolkit/lib/ | grep -v "^d" | awk {'print $9'}); do ln -s /opt/pth-toolkit/lib/$file /opt/smbexec/lib/$file; done
 	# symlink the patched pth-toolkit binaries so they are accessible from everywhere
-	for file in $(ls -l /opt/pth-toolkit/ | grep "pth" | awk {'print $9'}); do sudo ln -s /opt/pth-toolkit/$file /usr/bin/$file; done
+	for file in $(ls --color=never -l /opt/pth-toolkit/ | grep "pth" | awk {'print $9'}); do sudo ln -s /opt/pth-toolkit/$file /usr/bin/$file 2>/dev/null; done
 	# symlink the unpatched pth-toolkit bin files so they are accessible for binaries with relative paths hard coded
 	mkdir /opt/smbexec/bin
 	for file in $(ls --color=never -l /opt/pth-toolkit/bin/ | awk {'print $9'}); do sudo ln -s /opt/pth-toolkit/bin/$file /opt/smbexec/bin/$file; done

--- a/install.sh
+++ b/install.sh
@@ -332,12 +332,12 @@ if [ ! $(grep -i kali /etc/issue) ]; then
                 git clone https://github.com/byt3bl33d3r/pth-toolkit.git
 	fi
 	# symlink the library files to be inside "smbexec/lib" so they are accessible for binaries with relative paths hard coded
-	for file in $(ls --color=never -l /opt/pth-toolkit/lib/ | grep -v "^d" | awk {'print $9'}); do ln -s /opt/pth-toolkit/lib/$file /opt/smbexec/lib/$file; done
+	for file in $(ls --color=never -l /opt/pth-toolkit/lib/ | grep -v "^d" | awk {'print $9'}); do ln -s /opt/pth-toolkit/lib/$file /opt/smbexec/lib/$file 2>/dev/null; done
 	# symlink the patched pth-toolkit binaries so they are accessible from everywhere
 	for file in $(ls --color=never -l /opt/pth-toolkit/ | grep "pth" | awk {'print $9'}); do sudo ln -s /opt/pth-toolkit/$file /usr/bin/$file 2>/dev/null; done
 	# symlink the unpatched pth-toolkit bin files so they are accessible for binaries with relative paths hard coded
 	mkdir /opt/smbexec/bin
-	for file in $(ls --color=never -l /opt/pth-toolkit/bin/ | awk {'print $9'}); do sudo ln -s /opt/pth-toolkit/bin/$file /opt/smbexec/bin/$file; done
+	for file in $(ls --color=never -l /opt/pth-toolkit/bin/ | awk {'print $9'}); do sudo ln -s /opt/pth-toolkit/bin/$file /opt/smbexec/bin/$file 2>/dev/null; done
         # symlink the below two pth-toolkit patched binaries so they are where smbexec expects them to be
 	ln -s /opt/pth-toolkit/pth-winexe $path/progs/smbwinexe
         ln -s /opt/pth-toolkit/pth-smbclient $path/progs/smbexeclient

--- a/install.sh
+++ b/install.sh
@@ -327,10 +327,18 @@ if [ ! $(grep -i kali /etc/issue) ]; then
         # apply YG-HT patch for non Kali dists
 	echo -e "\n\e[1;32m[+]\e[0m Looks like we are not on a Kali install, making smbexeclient and winexe work"
         cd /opt
+	# get the latest pth-toolkit
         git clone https://github.com/byt3bl33d3r/pth-toolkit.git
-        cd $path/progs/
-        ln -s /opt/pth-toolkit/pth-winexe smbwinexe
-        ln -s /opt/pth-toolkit/pth-smbclient smbexeclient
+	# symlink the library files to be inside "smbexec/lib" so they are accessible for binaries with relative paths hard coded
+	for file in $(ls -l /opt/pth-toolkit/lib/ | grep -v "^d" | awk {'print $9'}); do ln -s /opt/pth-toolkit/lib/$file /opt/smbexec/lib/$file; done
+	# symlink the patched pth-toolkit binaries so they are accessible from everywhere
+	for file in $(ls -l /opt/pth-toolkit/ | grep "pth" | awk {'print $9'}); do sudo ln -s /opt/pth-toolkit/$file /usr/bin/$file; done
+	# symlink the unpatched pth-toolkit bin files so they are accessible for binaries with relative paths hard coded
+	mkdir /opt/smbexec/bin
+	for file in $(ls --color=never -l /opt/pth-toolkit/bin/ | awk {'print $9'}); do echo /usr/bin/$file; sudo ln -s /opt/pth-toolkit/bin/$file /opt/smbexec/bin/$file; done
+        # symlink the below two pth-toolkit patched binaries so they are where smbexec expects them to be
+	ln -s /opt/pth-toolkit/pth-winexe $path/progs/smbwinexe
+        ln -s /opt/pth-toolkit/pth-smbclient $path/progs/smbexeclient
 fi
 
 if [ -e $path/progs/smbexeclient ]; then

--- a/install.sh
+++ b/install.sh
@@ -328,14 +328,16 @@ if [ ! $(grep -i kali /etc/issue) ]; then
 	echo -e "\n\e[1;32m[+]\e[0m Looks like we are not on a Kali install, making smbexeclient and winexe work"
         cd /opt
 	# get the latest pth-toolkit
-        git clone https://github.com/byt3bl33d3r/pth-toolkit.git
+	if [ ! -d /opt/pth-toolkit ]; then
+                git clone https://github.com/byt3bl33d3r/pth-toolkit.git
+	fi
 	# symlink the library files to be inside "smbexec/lib" so they are accessible for binaries with relative paths hard coded
 	for file in $(ls -l /opt/pth-toolkit/lib/ | grep -v "^d" | awk {'print $9'}); do ln -s /opt/pth-toolkit/lib/$file /opt/smbexec/lib/$file; done
 	# symlink the patched pth-toolkit binaries so they are accessible from everywhere
 	for file in $(ls -l /opt/pth-toolkit/ | grep "pth" | awk {'print $9'}); do sudo ln -s /opt/pth-toolkit/$file /usr/bin/$file; done
 	# symlink the unpatched pth-toolkit bin files so they are accessible for binaries with relative paths hard coded
 	mkdir /opt/smbexec/bin
-	for file in $(ls --color=never -l /opt/pth-toolkit/bin/ | awk {'print $9'}); do echo /usr/bin/$file; sudo ln -s /opt/pth-toolkit/bin/$file /opt/smbexec/bin/$file; done
+	for file in $(ls --color=never -l /opt/pth-toolkit/bin/ | awk {'print $9'}); do sudo ln -s /opt/pth-toolkit/bin/$file /opt/smbexec/bin/$file; done
         # symlink the below two pth-toolkit patched binaries so they are where smbexec expects them to be
 	ln -s /opt/pth-toolkit/pth-winexe $path/progs/smbwinexe
         ln -s /opt/pth-toolkit/pth-smbclient $path/progs/smbexeclient


### PR DESCRIPTION
This one is  for non-kali builds that get a copy of pth-toolkit.  The toolkit doesn't put things in the expected places for smbexec.  This builds on previous patch that got it to install, but not execute correctly.  